### PR TITLE
Cleaned code to compile with -Wextra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ THEME	:=
 #---------------------------------------------------------------------------------
 ARCH	:=	-mthumb -mthumb-interwork
 
-CFLAGS	:=	-g -Wall -O2\
+CFLAGS	:=	-g -Wall -O2 -Wextra\
 			-march=armv5te -mtune=arm946e-s -fomit-frame-pointer\
 			-ffast-math -std=c99\
 			$(ARCH)

--- a/source/common.h
+++ b/source/common.h
@@ -44,14 +44,14 @@
 
 inline char* strupper(const char* str) {
     char* buffer = (char*)malloc(strlen(str) + 1);
-    for (int i = 0; i < strlen(str); ++i)
+    for (size_t i = 0; i < strlen(str); ++i)
         buffer[i] = toupper((unsigned)str[i]);
     return buffer;
 }
 
 inline char* strlower(const char* str) {
     char* buffer = (char*)malloc(strlen(str) + 1);
-    for (int i = 0; i < strlen(str); ++i)
+    for (size_t i = 0; i < strlen(str); ++i)
         buffer[i] = tolower((unsigned)str[i]);
     return buffer;
 }

--- a/source/draw.c
+++ b/source/draw.c
@@ -78,13 +78,13 @@ void DrawCharacter(u8* screen, int character, int x, int y, int color, int bgcol
 
 void DrawString(u8* screen, const char *str, int x, int y, int color, int bgcolor)
 {
-    for (int i = 0; i < strlen(str); i++)
+    for (size_t i = 0; i < strlen(str); i++)
         DrawCharacter(screen, str[i], x + i * 8, y, color, bgcolor);
 }
 
 void DrawStringF(int x, int y, bool use_top, const char *format, ...)
 {
-    char str[512] = {}; // 512 should be more than enough
+    char str[512] = { 0 }; // 512 should be more than enough
     va_list va;
 
     va_start(va, format);

--- a/source/emunand9.c
+++ b/source/emunand9.c
@@ -5,10 +5,10 @@
 #include "fatfs/sdmmc.h"
 
 #define BUFFER_ADDRESS  ((u8*) 0x21000000)
-#define BUFFER_MAX_SIZE (8 * 1024 * 1024)
+#define BUFFER_MAX_SIZE ((u32)(8 * 1024 * 1024))
 #define FCRAM_END       ((u8*) 0x28000000)
 
-#define NAND_SECTOR_SIZE 0x200
+#define NAND_SECTOR_SIZE ((u32)0x200)
 #define SECTORS_PER_READ (BUFFER_MAX_SIZE / NAND_SECTOR_SIZE)
 
 #define SD_MINFREE_SECTORS  ((1024 * 1024 * 1024) / 0x200)  // have at least 1GB free
@@ -212,7 +212,7 @@ u32 FormatSdCard(u32 param)
     if (starter_size && FileOpen("starter.bin")) {
         Debug("Copying starter.bin to memory...");
         starter_size = FileGetSize();
-        if (starter_size > (FCRAM_END - buffer)) {
+        if (starter_size > ((u32)(FCRAM_END - buffer))) {
             Debug("File is %ikB, exceeds RAM size", starter_size / 1024);
             FileClose();
             return 1;
@@ -374,6 +374,7 @@ u32 FormatSdCard(u32 param)
 
 u32 CompleteSetupEmuNand(u32 param)
 {
+    (void)param; // Unused
     u32 res = FormatSdCard(SD_SETUP_EMUNAND | SD_USE_STARTER);
     if (res != 0) return res;
     Debug("");

--- a/source/i2c.c
+++ b/source/i2c.c
@@ -3,7 +3,7 @@
 
 //-----------------------------------------------------------------------------
 
-static const struct { u8 bus_id, reg_addr } dev_data[] = {
+static const struct { u8 bus_id, reg_addr; } dev_data[] = {
     {0, 0x4A}, {0, 0x7A}, {0, 0x78},
     {1, 0x4A}, {1, 0x78}, {1, 0x2C},
     {1, 0x2E}, {1, 0x40}, {1, 0x44},
@@ -11,35 +11,35 @@ static const struct { u8 bus_id, reg_addr } dev_data[] = {
     {2, 0xA4}, {2, 0x9A}, {2, 0xA0},
 };
 
-const inline u8 i2cGetDeviceBusId(u8 device_id) {
+inline u8 i2cGetDeviceBusId(u8 device_id) {
     return dev_data[device_id].bus_id;
 }
 
-const inline u8 i2cGetDeviceRegAddr(u8 device_id) {
+inline u8 i2cGetDeviceRegAddr(u8 device_id) {
     return dev_data[device_id].reg_addr;
 }
 
 //-----------------------------------------------------------------------------
 
-static vu8* const reg_data_addrs[] = {
+static vu8* reg_data_addrs[] = {
     (vu8*)(I2C1_REG_OFF + I2C_REG_DATA),
     (vu8*)(I2C2_REG_OFF + I2C_REG_DATA),
     (vu8*)(I2C3_REG_OFF + I2C_REG_DATA),
 };
 
-inline vu8* const i2cGetDataReg(u8 bus_id) {
+inline vu8* i2cGetDataReg(u8 bus_id) {
     return reg_data_addrs[bus_id];
 }
 
 //-----------------------------------------------------------------------------
 
-static vu8* const reg_cnt_addrs[] = {
+static vu8* reg_cnt_addrs[] = {
     (vu8*)(I2C1_REG_OFF + I2C_REG_CNT),
     (vu8*)(I2C2_REG_OFF + I2C_REG_CNT),
     (vu8*)(I2C3_REG_OFF + I2C_REG_CNT),
 };
 
-inline vu8* const i2cGetCntReg(u8 bus_id) {
+inline vu8* i2cGetCntReg(u8 bus_id) {
     return reg_cnt_addrs[bus_id];
 }
 
@@ -114,7 +114,7 @@ bool i2cReadRegisterBuffer(unsigned int dev_id, int reg, u8* buffer, size_t buf_
     }
 
     if (buf_size != 1) {
-        for (int i = 0; i < buf_size - 1; i++) {
+        for (size_t i = 0; i < buf_size - 1; i++) {
             i2cWaitBusy(bus_id);
             *i2cGetCntReg(bus_id) = 0xF0;
             i2cWaitBusy(bus_id);

--- a/source/i2c.h
+++ b/source/i2c.h
@@ -15,11 +15,11 @@
 #define I2C_DEV_GYRO 10
 #define I2C_DEV_IR   13
 
-const u8 i2cGetDeviceBusId(u8 device_id);
-const u8 i2cGetDeviceRegAddr(u8 device_id);
+u8 i2cGetDeviceBusId(u8 device_id);
+u8 i2cGetDeviceRegAddr(u8 device_id);
 
-vu8* const i2cGetDataReg(u8 bus_id);
-vu8* const i2cGetCntReg(u8 bus_id);
+vu8* i2cGetDataReg(u8 bus_id);
+vu8* i2cGetCntReg(u8 bus_id);
 
 void i2cWaitBusy(u8 bus_id);
 bool i2cGetResult(u8 bus_id);

--- a/source/main.c
+++ b/source/main.c
@@ -56,7 +56,7 @@ MenuInfo menu[] =
         }
     },
     {
-        NULL, 0, {}, // empty menu to signal end
+        NULL, 0, { { 0 } }, // empty menu to signal end
     }
 };
 

--- a/source/menu.c
+++ b/source/menu.c
@@ -182,7 +182,7 @@ u32 ProcessMenu(MenuInfo* info, u32 n_entries_main)
             index = (index == 0) ? currMenu->n_entries - 1 : index - 1;
             full_draw = false;
         } else if ((pad_state & BUTTON_R1) && (menuLvl == 1)) {
-            if (++currMenu - info >= n_entries_main) currMenu = info;
+            if (++currMenu - info >= (ssize_t)n_entries_main) currMenu = info;
             index = 0;
         } else if ((pad_state & BUTTON_L1) && (menuLvl == 1)) {
             if (--currMenu < info) currMenu = info + n_entries_main - 1;


### PR DESCRIPTION
Added -Wextra to Makefile and corrected warnings that were emitted by
GCC. Also tried to add -Wpedantic, but some warnings emitted by it could
not be removed (due to macro usage of min and max using GCC extensions).

The only part of this pull request that makes me a little uneasy is the casts I
added at source/emunand9.c:215 and source/menu.c:185. I did not implement
any checking before the casts to make sure that the previous number fit into the
casted type. For the cast in source/emunand9.c:215, so long as the constants
used for that one remains, well, constant, that cast should be safe.
